### PR TITLE
security: lock the /__internal plane (registry/init unroutable; optional host secret)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -157,6 +157,12 @@ in the first prototype: never let a report disagree with the ledger.)
   each, one writer each, fenced by celld epochs. A broken fragment can only
   damage its own database.
 - Workflow code runs in loader isolates with no access to other cells.
+- The internal plane (`/__internal/f/<name>/…`) serves exactly one caller:
+  ctx loopback from loader isolates, authenticated per cell by run tokens.
+  The registry and cell-init are never reachable over HTTP — only via the
+  router's own DO binding. Hosts that want a second lock set
+  `FRAGMENT_HOST_SECRET` (celld: `CELLD_VAR_FRAGMENT_HOST_SECRET`; CF:
+  wrangler secret), which every loopback call must then carry.
 - celld does not terminate TLS and does not authenticate users. That is the
   ingress's job (Caddy in prod; nothing locally). Wildcard subdomain →
   `Host: <name>.frag.example` reaches the same router; path-based URLs work

--- a/README.md
+++ b/README.md
@@ -75,7 +75,9 @@ Worker Loader is the one exotic binding). Same code, different bindings:
 ```
 cd runtime && npx wrangler login        # once, browser OAuth
 ../scripts/deploy-cf deploy             # deploys + bakes in the worker URL
-../scripts/deploy-cf secret             # optional: OPENROUTER_API_KEY from .env
+../scripts/deploy-cf secret             # OPENROUTER_API_KEY from .env, plus
+                                        # FRAGMENT_HOST_SECRET (generated) that
+                                        # locks /__internal to ctx loopback
 fragment --host https://<you>.workers.dev create hello
 ```
 

--- a/deploy/env.example
+++ b/deploy/env.example
@@ -15,3 +15,9 @@ S3_ENDPOINT=https://ACCOUNT-ID.s3.latitude.sh
 # sigv4 signing region. Latitude doesn't document one; if requests fail
 # signature/region checks, try your bucket's site (e.g. nyc).
 AWS_REGION=us-east-1
+
+# Shared secret for the runtime-internal /__internal plane (ctx loopback from
+# workflow/app isolates). Generate with: openssl rand -hex 32. Without it the
+# plane is still gated per-cell by run tokens and registry/init are blocked;
+# with it, a caller must also carry x-fragment-host-secret.
+FRAGMENT_HOST_SECRET=

--- a/docs/api.md
+++ b/docs/api.md
@@ -82,6 +82,8 @@ plus plain-JSON env:
 
 - `FRAGMENT_INTERNAL_URL` — e.g. `http://127.0.0.1:8789/__internal`
 - `FRAGMENT_RUN_TOKEN` — per-run/per-draft random token (cell validates)
+- `FRAGMENT_HOST_SECRET` — only present when the host sets it; ctx forwards
+  it as `x-fragment-host-secret`
 
 `fragment-ctx.mjs` implements `ctx` over fetch against `/__internal`:
 

--- a/docs/deploy-vps.md
+++ b/docs/deploy-vps.md
@@ -93,8 +93,9 @@ editor /etc/celld.env        # fill from deploy/env.example
 ```
 
 `/etc/celld.env` holds `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`,
-`AWS_REGION`. Root-only, never committed, never pasted anywhere. The systemd
-unit reads it via `EnvironmentFile=`.
+`AWS_REGION`, and (recommended) `FRAGMENT_HOST_SECRET` — generate with
+`openssl rand -hex 32`. Root-only, never committed, never pasted anywhere.
+The systemd unit reads it via `EnvironmentFile=`.
 
 ## 3. celld service
 

--- a/runtime/src/cell.js
+++ b/runtime/src/cell.js
@@ -611,6 +611,9 @@ export class FragmentCell {
         FRAGMENT_INTERNAL_URL: this.internalBase(),
         FRAGMENT_RUN_TOKEN: this.makeToken(scope),
         FRAGMENT_SCOPE: scope.kind,
+        // forwarded by ctx as x-fragment-host-secret; checked by the router
+        // on /__internal when the host sets FRAGMENT_HOST_SECRET
+        ...(this.env.FRAGMENT_HOST_SECRET ? { FRAGMENT_HOST_SECRET: this.env.FRAGMENT_HOST_SECRET } : {}),
       },
     }));
     return worker.getEntrypoint ? worker.getEntrypoint() : worker;

--- a/runtime/src/ctx-shim.js
+++ b/runtime/src/ctx-shim.js
@@ -5,9 +5,11 @@ export const CTX_SHIM_SOURCE = `
 export async function makeCtx(env) {
   const base = env.FRAGMENT_INTERNAL_URL;
   const tok = env.FRAGMENT_RUN_TOKEN;
+  const hsec = env.FRAGMENT_HOST_SECRET || "";
   const scope = env.FRAGMENT_SCOPE || "run";
   const call = async (path, opts = {}) => {
     const headers = Object.assign({}, opts.headers || {}, { "x-fragment-token": tok });
+    if (hsec) headers["x-fragment-host-secret"] = hsec;
     const r = await fetch(base + path, Object.assign({}, opts, { headers }));
     if (!r.ok) throw new Error("fragment ctx " + path + " -> " + r.status + ": " + (await r.text()));
     return r;

--- a/runtime/src/index.js
+++ b/runtime/src/index.js
@@ -1,6 +1,6 @@
 // Router worker: public entry. Routes to cells, verifies NIP-98 on control
 // routes, stamps x-fragment-pubkey (and strips any inbound spoof).
-import { verifyNip98 } from "./auth.js";
+import { verifyNip98, sha256Hex } from "./auth.js";
 import { RT_CLIENT_SOURCE } from "./rt-client.js";
 
 export { FragmentCell } from "./cell.js";
@@ -70,6 +70,29 @@ export default {
       if (path.startsWith("/__internal/f/")) {
         const rest = path.slice("/__internal/f/".length);
         const name = rest.slice(0, rest.indexOf("/"));
+        // The internal plane exists only for loader-isolate loopback traffic
+        // (workflow/app/rooms ctx calls), which cells authenticate with their
+        // own run tokens. Two namespaces are never reachable over HTTP, from
+        // anyone: the registry and cell init. Both are exercised exclusively
+        // through the FRAGMENT binding by the router itself (create flow,
+        // syncRolesToRegistry, slug-map). Without this block, anyone who can
+        // reach the router could mint registry rows without a key, map
+        // arbitrary slugs onto other fragments, or win the __cell/init race
+        // on a not-yet-initialized name.
+        if (name === "_registry" || rest.slice(name.length).startsWith("/__cell/")) {
+          return new Response("not found", { status: 404 });
+        }
+        // Defense in depth when the host sets FRAGMENT_HOST_SECRET (celld:
+        // CELLD_VAR_FRAGMENT_HOST_SECRET; CF: a wrangler secret): loopback
+        // calls must carry x-fragment-host-secret. Cells stamp the value into
+        // loaded workers' env, so ctx keeps working unchanged. Unset (plain
+        // local dev) → per-cell run-token auth only, as before.
+        const want = env.FRAGMENT_HOST_SECRET;
+        if (want) {
+          const got = request.headers.get("x-fragment-host-secret") || "";
+          const [hw, hg] = await Promise.all([sha256Hex(want), sha256Hex(got)]);
+          if (hw !== hg) return json({ error: "bad host secret" }, 403);
+        }
         return toCell(name, path, null);
       }
 

--- a/scripts/deploy-cf
+++ b/scripts/deploy-cf
@@ -40,6 +40,12 @@ case "${1:-}" in
     fi
     printf '%s' "$OPENROUTER_API_KEY" | "${W[@]}" secret put OPENROUTER_API_KEY
     echo "secret set."
+    # Also lock the /__internal loopback plane (recommended; generates one if absent).
+    host_secret="${FRAGMENT_HOST_SECRET:-$(openssl rand -hex 32)}"
+    printf '%s' "$host_secret" | "${W[@]}" secret put FRAGMENT_HOST_SECRET
+    echo "FRAGMENT_HOST_SECRET set. Keep this value in .env — redeploying the runtime"
+    echo "does not need it, but local CLI-driven tests against this host will."
+    [ -z "${FRAGMENT_HOST_SECRET:-}" ] && echo "(generated) FRAGMENT_HOST_SECRET=$host_secret"
     ;;
   tail) "${W[@]}" tail ;;
   url) worker_url ;;

--- a/scripts/dev
+++ b/scripts/dev
@@ -59,6 +59,7 @@ start_celld() {
   CELLD_WATCH="$PWD/$DEV/watch" \
   CELLD_VAR_FRAGMENT_INTERNAL_URL="http://127.0.0.1:$CELLD_PORT" \
   ${OPENROUTER_API_KEY:+CELLD_VAR_OPENROUTER_API_KEY="$OPENROUTER_API_KEY"} \
+  ${FRAGMENT_HOST_SECRET:+CELLD_VAR_FRAGMENT_HOST_SECRET="$FRAGMENT_HOST_SECRET"} \
   nohup celld --bucket "$BUCKET" --listen "127.0.0.1:$CELLD_PORT" > "$DEV/celld.log" 2>&1 &
   echo $! > "$DEV/celld.pid"
   sleep 3


### PR DESCRIPTION
## Problem

The router forwarded `/__internal/f/<name>/...` to any cell with no gate. Cell-side run tokens covered ctx loopback, but two namespaces had **no auth at all**:

- **`_registry`**: anyone who could reach the router could `POST /__internal/f/_registry/__registry/create` (mint registry rows without a NIP-98 key), poison `slug-map` with arbitrary slug→fragment mappings, or rewrite `roles-sync` rows.
- **`__cell/init`**: an attacker could initialize a not-yet-created fragment name with their own owner key and capture the view/inbox tokens meant for the real creator.

On celld deploys this was masked by a network-topology assumption ("celld's listener only accepts Caddy's traffic"). On Cloudflare there is no such layer — `/__internal` is just public.

## Fix

1. **Router-level, unconditional:** `/__internal/f/_registry/...` and `/__internal/f/<name>/__cell/...` now return 404. Both remain reachable only via the `FRAGMENT` DO binding that the runtime itself uses (create flow, roles-sync, slug-map) — which is the only legitimate caller.
2. **Defense in depth, opt-in:** hosts can set `FRAGMENT_HOST_SECRET` (celld: `CELLD_VAR_FRAGMENT_HOST_SECRET`; CF: `scripts/deploy-cf secret` now sets it, generating one if absent). Every loopback call must then carry `x-fragment-host-secret`. Cells stamp the value into loaded workers' env so ctx keeps working unchanged. Unset → token-only behavior exactly as before.

Secret comparison goes through sha256 on both sides to avoid timing leaks.

## Verification

Executed against an isolated celld+azurite stack running this branch:

- registry create over HTTP → 404; cell init over HTTP → 404
- missing / wrong host secret → 403
- workflow run whose ctx (`files.write`, `log`) round-trips through the locked plane in **secret mode** and in **no-secret mode** (back-compat)

Docs updated: ARCHITECTURE (isolation section), README CF section, docs/api.md loopback env list, deploy-vps.md + deploy/env.example.

Follow-ups worth considering (not in this PR): drop run-token support via `?t=` query param (tokens leak into access logs), constant-time compares for view/inbox tokens.