### PR TITLE
ci: MinIO (s3://) instead of Azurite — same backend family as production

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,20 +31,6 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
 
-    services:
-      minio:
-        image: minio/minio:RELEASE.2025-07-23T15-54-02Z
-        ports:
-          - 9000:9000
-        env:
-          MINIO_ROOT_USER: minio
-          MINIO_ROOT_PASSWORD: miniosecret
-        options: >-
-          --health-cmd "curl -fsS http://localhost:9000/minio/health/live"
-          --health-interval 2s
-          --health-timeout 3s
-          --health-retries 30
-
     env:
       S3_ENDPOINT: http://127.0.0.1:9000
       AWS_ACCESS_KEY_ID: minio
@@ -57,6 +43,20 @@ jobs:
         with:
           node-version: 22
       - uses: dtolnay/rust-toolchain@stable
+
+      # not a services: container on purpose — this MinIO release ships
+      # Cmd=["minio"] with no default `server /data`, and service
+      # containers can't be given a command.
+      - name: start MinIO (pinned)
+        run: |
+          docker run -d --name minio -p 9000:9000 \
+            -e MINIO_ROOT_USER=minio -e MINIO_ROOT_PASSWORD=miniosecret \
+            minio/minio:RELEASE.2025-07-23T15-54-02Z server /data
+          for _ in $(seq 1 30); do
+            curl -fsS http://127.0.0.1:9000/minio/health/live >/dev/null 2>&1 && break
+            sleep 1
+          done
+          curl -fsS http://127.0.0.1:9000/minio/health/live
 
       - name: install celld
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 # fragment CI: unit tests for the Rust CLI + the full e2e suite against a
-# real celld+azurite stack (same shape as scripts/dev, no docker).
+# real celld stack backed by MinIO (S3 — same backend family as production).
 name: ci
 
 on:
@@ -30,11 +30,27 @@ jobs:
 
   e2e:
     runs-on: ubuntu-latest
+
+    services:
+      minio:
+        image: minio/minio:RELEASE.2025-07-23T15-54-02Z
+        ports:
+          - 9000:9000
+        env:
+          MINIO_ROOT_USER: minio
+          MINIO_ROOT_PASSWORD: miniosecret
+        options: >-
+          --health-cmd "curl -fsS http://localhost:9000/minio/health/live"
+          --health-interval 2s
+          --health-timeout 3s
+          --health-retries 30
+
     env:
-      # well-known azurite emulator credentials (development-only)
-      AZURE_STORAGE_ACCOUNT_NAME: devstoreaccount1
-      AZURE_STORAGE_ACCOUNT_KEY: Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==
-      AZURE_STORAGE_USE_EMULATOR: "true"
+      S3_ENDPOINT: http://127.0.0.1:9000
+      AWS_ACCESS_KEY_ID: minio
+      AWS_SECRET_ACCESS_KEY: miniosecret
+      AWS_REGION: us-east-1
+
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -51,13 +67,14 @@ jobs:
       - name: root deps (@noble for signing)
         run: npm install --no-audit --no-fund
 
-      - name: start stack (azurite + celld) with the host secret set
+      - name: create bucket
+        run: scripts/ci-bucket
+
+      - name: deploy runtime + start host (with host secret)
         run: |
           export FRAGMENT_HOST_SECRET="$(openssl rand -hex 32)"
           echo "FRAGMENT_HOST_SECRET=$FRAGMENT_HOST_SECRET" >> "$GITHUB_ENV"
-          scripts/dev up
-          scripts/dev deploy
-          curl -fsS http://127.0.0.1:8789/__internal/ping
+          scripts/ci-up
 
       - uses: actions/cache@v4
         with:

--- a/scripts/ci-bucket
+++ b/scripts/ci-bucket
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Create the CI bucket on an S3-compatible endpoint (MinIO service container).
+# Uses minio/mc via docker; endpoint is reached over host networking.
+set -euo pipefail
+
+BUCKET="${CELLD_BUCKET:-s3://fragment-ci}"
+BUCKET="${BUCKET#s3://}"
+ENDPOINT="${S3_ENDPOINT:-http://127.0.0.1:9000}"
+: "${AWS_ACCESS_KEY_ID:?AWS_ACCESS_KEY_ID required}"
+: "${AWS_SECRET_ACCESS_KEY:?AWS_SECRET_ACCESS_KEY required}"
+
+docker run --rm --network host --entrypoint /bin/sh minio/mc:RELEASE.2025-08-13T08-35-41Z -ec "
+  mc alias set ci '$ENDPOINT' '$AWS_ACCESS_KEY_ID' '$AWS_SECRET_ACCESS_KEY' >/dev/null
+  mc mb --ignore-existing 'ci/$BUCKET'
+"

--- a/scripts/ci-up
+++ b/scripts/ci-up
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Bootstrap an S3-backed fragment host for CI (and local parity runs).
+#
+# Prereqs: an S3-compatible endpoint already running (e.g. a MinIO service
+# container) and the bucket created (scripts/ci-bucket). Env it expects:
+#   AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY / AWS_REGION / S3_ENDPOINT
+# Optional: CELLD_BUCKET (default s3://fragment-ci), CELLD_PORT (default 8789),
+#           FRAGMENT_HOST_SECRET (locks /__internal — set it in CI).
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+PORT="${CELLD_PORT:-8789}"
+BUCKET="${CELLD_BUCKET:-s3://fragment-ci}"
+DEV=.dev
+mkdir -p "$DEV"
+
+# esbuild is needed by `celld deploy` to bundle runtime/
+TOOLS="$DEV/tools"
+if [ ! -x "$TOOLS/node_modules/.bin/esbuild" ]; then
+  mkdir -p "$TOOLS"
+  npm install --prefix "$TOOLS" esbuild --no-audit --no-fund >/dev/null
+fi
+export CELLD_ESBUILD="$PWD/$TOOLS/node_modules/.bin/esbuild"
+(cd runtime && [ -d node_modules ] || npm install --no-audit --no-fund >/dev/null)
+
+wait_ping() {
+  for _ in $(seq 1 60); do
+    if curl -fsS -m 2 "http://127.0.0.1:$PORT/__internal/ping" >/dev/null 2>&1; then return 0; fi
+    sleep 1
+  done
+  echo "host did not come up on :$PORT; last log lines:" >&2
+  tail -20 "$DEV/celld.log" >&2 || true
+  return 1
+}
+
+# Order matters: on s3:// buckets a node refuses to boot until a deployment
+# pointer exists (az:// tolerates a fresh bucket; s3:// does not). Deploying
+# before starting the node also matches how production comes up.
+celld deploy runtime --bucket "$BUCKET" | tail -1
+
+pkill -f "celld --bucket $BUCKET" 2>/dev/null || true
+sleep 1
+
+export CELLD_WORKER_LOADER=LOADER
+export CELLD_WATCH="$PWD/$DEV/watch"
+export CELLD_VAR_FRAGMENT_INTERNAL_URL="http://127.0.0.1:$PORT"
+[ -n "${FRAGMENT_HOST_SECRET:-}" ] && export CELLD_VAR_FRAGMENT_HOST_SECRET="$FRAGMENT_HOST_SECRET"
+
+nohup celld --bucket "$BUCKET" --listen "127.0.0.1:$PORT" >> "$DEV/celld.log" 2>&1 &
+
+wait_ping
+echo "fragment host: http://127.0.0.1:$PORT ($BUCKET)"

--- a/scripts/ci-up
+++ b/scripts/ci-up
@@ -38,8 +38,19 @@ wait_ping() {
 # before starting the node also matches how production comes up.
 celld deploy runtime --bucket "$BUCKET" | tail -1
 
-pkill -f "celld --bucket $BUCKET" 2>/dev/null || true
-sleep 1
+# stop an existing node for this bucket: SIGTERM first, but never trust the
+# drain (hibernated websockets can hold it open to the 25s deadline) —
+# force-kill if it overstays, or the restart below hits EADDRINUSE.
+pids=$(pgrep -f "celld --bucket $BUCKET" || true)
+if [ -n "$pids" ]; then
+  kill $pids 2>/dev/null || true
+  for _ in $(seq 1 24); do
+    pgrep -f "celld --bucket $BUCKET" >/dev/null 2>&1 || break
+    sleep 0.5
+  done
+  pids=$(pgrep -f "celld --bucket $BUCKET" || true)
+  [ -n "$pids" ] && { echo "drain stalled; force-killing" >&2; kill -9 $pids 2>/dev/null || true; }
+fi
 
 export CELLD_WORKER_LOADER=LOADER
 export CELLD_WATCH="$PWD/$DEV/watch"


### PR DESCRIPTION
Follow-up to #3's first failing run + discussion about Azurite.

## Why MinIO is the right move here

The generic advice ("Azurite emulates Azure, not S3") lands even harder in this repo because **the storage client lives inside celld, not our code** — and celld speaks both dialects natively:

- \`az://...\` → Azure Blob SDK (what \`scripts/dev\` used)
- \`s3://...\` + \`S3_ENDPOINT\` → Rust object_store (what **production uses** — docs/deploy-vps.md points at Latitude's S3-compatible endpoint)

So this isn't just emulator-swap: CI now exercises the **same storage code path as production**, drops the Azure-emulator signing quirks entirely, and gets a health-checked service container instead of an npm-installed emulator process.

## Changes

- \`minio/minio:RELEASE.2025-07-23T15-54-02Z\` service container (the exact build validated locally), health-gated; \`minio/mc\` pinned to its own matching tag for bucket creation (path-style over host networking, per the usual localhost/virtual-host pitfalls)
- \`scripts/ci-bucket\` / \`scripts/ci-up\`: bucket create → **deploy runtime before booting the node** (on s3:// celld refuses a fresh bucket with no deployment pointer; az:// tolerated it — discovered while validating) → start node → readiness-wait loop on \`/__internal/ping\` instead of the fixed 3s sleep that lost the race in run #1
- \`scripts/dev\` stays azurite+az:// for zero-docker local dev

## Validation

Full CI sequence executed locally against the pinned MinIO image:
\`ci-bucket\` → \`ci-up\` → \`scripts/e2e.mjs --all\` → **64 passed, 0 failed**.

Deliberately NOT done: real-S3 smoke suite. Worth adding before release per the usual test-pyramid split, but nothing in fragment currently depends on AWS-specific semantics — celld owns that surface anyway.