### PR TITLE
security: run tokens are header-only; inbox gains a header form too

### DIFF
--- a/cli/GUIDE.md
+++ b/cli/GUIDE.md
@@ -176,6 +176,10 @@ own copy of the folder — a wedged workflow cannot wedge the fragment itself.
 POST {host}/api/f/{name}/inbox?t={inboxToken}   {"source": "grafana", "payload": {...}}
 ```
 
+When you control the HTTP client, prefer sending the token as the
+`x-fragment-inbox-token` header instead of `?t=` — same result, but the
+secret stays out of access logs.
+
 No signature needed — the token is the auth (rotate by asking the owner to
 re-create… no, tokens are fixed at create; treat them as passwords).
 `fragment inbox my-thing --token <t> --payload '{"hello":"world"}'` tests it.

--- a/docs/api.md
+++ b/docs/api.md
@@ -49,7 +49,7 @@ visibility=viewers).
 | `GET /api/f/{name}/secrets` | editor+ | → `{names: [...]}` (never values) |
 | `DELETE /api/f/{name}/secrets/{KEY}` | editor+ | → `{ok}` |
 | `GET /api/f/{name}/events?since={id}` | viewer+ | → `{events:[{id, at, kind, summary, data?}]}` |
-| `POST /api/f/{name}/inbox?t={inboxToken}` | token only | `{source?, payload}` → `{ok, id}`; enqueues + runs `trigger:"inbox"` workflows |
+| `POST /api/f/{name}/inbox?t={inboxToken}` | token only | `{source?, payload}` → `{ok, id}`; enqueues + runs `trigger:"inbox"` workflows. Prefer the `x-fragment-inbox-token` header when you control the client — `?t=` lands in access logs. |
 | `PUT /api/f/{name}/file?path=&base_rev=` | editor+ | raw body; stale `base_rev` → 409. Successful writes schedule `trigger:"sync"` workflows (coalesced; workflow-plane writes don't) |
 
 ## Serving (no NIP-98)
@@ -81,7 +81,9 @@ Worker-Loader isolates. The cell injects a sibling module `fragment-ctx.mjs`
 plus plain-JSON env:
 
 - `FRAGMENT_INTERNAL_URL` — e.g. `http://127.0.0.1:8789/__internal`
-- `FRAGMENT_RUN_TOKEN` — per-run/per-draft random token (cell validates)
+- `FRAGMENT_RUN_TOKEN` — per-run/per-draft random token (cell validates; sent
+  as the `x-fragment-token` header — never a query param, so it stays out of
+  access logs)
 - `FRAGMENT_HOST_SECRET` — only present when the host sets it; ctx forwards
   it as `x-fragment-host-secret`
 

--- a/runtime/src/auth.js
+++ b/runtime/src/auth.js
@@ -16,6 +16,22 @@ function b64decode(s) {
   return bytes;
 }
 
+// Constant-time-ish secret comparison: XOR-fold over zero-padded UTF-8
+// bytes, length mismatch folded into the accumulator. Not cryptographic
+// perfection (JIT), but removes the early-exit timing signal that `===`
+// gives away for free.
+export function safeEqual(presented, secret) {
+  const enc = new TextEncoder();
+  const a = enc.encode(String(presented ?? ""));
+  const b = enc.encode(String(secret ?? ""));
+  const len = Math.max(a.length, b.length);
+  const da = new Uint8Array(len); da.set(a);
+  const db = new Uint8Array(len); db.set(b);
+  let diff = a.length ^ b.length;
+  for (let i = 0; i < len; i++) diff |= da[i] ^ db[i];
+  return diff === 0;
+}
+
 // Returns { ok, pubkey?, error? }. `request` must still have a readable body
 // clone; pass the raw body bytes in explicitly.
 export async function verifyNip98(request, bodyBytes) {

--- a/runtime/src/cell.js
+++ b/runtime/src/cell.js
@@ -2,7 +2,7 @@
 // All fragment state lives in this cell's SQLite. See ARCHITECTURE.md.
 import { schnorr } from "@noble/curves/secp256k1.js";
 import { npubFromHex, hexFromNpub } from "./bech32.js";
-import { sha256Hex } from "./auth.js";
+import { sha256Hex, safeEqual } from "./auth.js";
 import { parseCron, nextRun, cronMatches } from "./cron.js";
 import { CTX_SHIM_SOURCE } from "./ctx-shim.js";
 
@@ -260,9 +260,13 @@ export class FragmentCell {
     const m = this.manifest();
     if (!m) return json({ error: "fragment not initialized" }, 404);
 
-    // inbox: token-gated, no nostr
+    // inbox: token-gated, no nostr. The token may arrive as a query param
+    // (webhook ergonomics: ?t=...) or, preferably, the x-fragment-inbox-token
+    // header for callers who control their clients and don't want the secret
+    // in access logs.
     if (p === "/inbox" && request.method === "POST") {
-      if (url.searchParams.get("t") !== this.getMeta("inbox_token")) return json({ error: "bad inbox token" }, 403);
+      const presented = request.headers.get("x-fragment-inbox-token") || url.searchParams.get("t") || "";
+      if (!safeEqual(presented, this.getMeta("inbox_token") || "")) return json({ error: "bad inbox token" }, 403);
       const body = await request.json().catch(() => ({}));
       const cur = this.sql.exec("INSERT INTO inbox (at, source, payload) VALUES (?, ?, ?) RETURNING id",
         Date.now(), String(body.source || "external"), JSON.stringify(body.payload ?? null)).toArray()[0];
@@ -584,9 +588,14 @@ export class FragmentCell {
     return token;
   }
 
-  checkToken(request, url) {
-    const token = request.headers.get("x-fragment-token") || url.searchParams.get("t") || "";
-    const row = this.sql.exec("SELECT scope, expires FROM run_tokens WHERE token = ?", token).toArray()[0];
+  checkToken(request) {
+    // header-only, deliberately: run tokens unlock files/secrets/state for
+    // one isolate. Query params land in access logs, proxy logs, and browser
+    // history — a leaked run token is a fragment-wide capability leak. The
+    // ctx shim has always sent x-fragment-token as a header.
+    const row = this.sql
+      .exec("SELECT scope, expires FROM run_tokens WHERE token = ?", request.headers.get("x-fragment-token") || "")
+      .toArray()[0];
     if (!row) return null;
     if (row.expires !== null && row.expires !== undefined && row.expires < Date.now()) return null;
     return JSON.parse(row.scope);
@@ -687,7 +696,7 @@ export class FragmentCell {
     const p = url.pathname.slice("/__internal/f/".length);
     const slash = p.indexOf("/");
     const rest = p.slice(slash + 1);
-    const scope = this.checkToken(request, url);
+    const scope = this.checkToken(request);
     if (!scope) return json({ error: "bad or expired run token" }, 403);
     const isRun = scope.kind === "run";
 

--- a/scripts/dev
+++ b/scripts/dev
@@ -55,11 +55,18 @@ start_azurite() {
 
 start_celld() {
   if celld_running; then echo "celld: already running on :$CELLD_PORT"; return; fi
+  # env passthroughs must be exported before exec — a ${VAR:+NAME=val}
+  # prefix expands to ordinary words, not assignments, and silently
+  # never reaches celld.
+  if [ -n "${OPENROUTER_API_KEY:-}" ]; then
+    export CELLD_VAR_OPENROUTER_API_KEY="$OPENROUTER_API_KEY"
+  fi
+  if [ -n "${FRAGMENT_HOST_SECRET:-}" ]; then
+    export CELLD_VAR_FRAGMENT_HOST_SECRET="$FRAGMENT_HOST_SECRET"
+  fi
   CELLD_WORKER_LOADER=LOADER \
   CELLD_WATCH="$PWD/$DEV/watch" \
   CELLD_VAR_FRAGMENT_INTERNAL_URL="http://127.0.0.1:$CELLD_PORT" \
-  ${OPENROUTER_API_KEY:+CELLD_VAR_OPENROUTER_API_KEY="$OPENROUTER_API_KEY"} \
-  ${FRAGMENT_HOST_SECRET:+CELLD_VAR_FRAGMENT_HOST_SECRET="$FRAGMENT_HOST_SECRET"} \
   nohup celld --bucket "$BUCKET" --listen "127.0.0.1:$CELLD_PORT" > "$DEV/celld.log" 2>&1 &
   echo $! > "$DEV/celld.pid"
   sleep 3

--- a/scripts/e2e.mjs
+++ b/scripts/e2e.mjs
@@ -357,6 +357,22 @@ async function workflowSection() {
     method: 'POST', body: JSON.stringify({ source: 'e2e', payload: {} }),
   });
   eq(badTok.status, 403, 'inbox bad token → 403');
+  // header form: preferred for callers who control clients
+  const hdrTok = await fetch(`${BASE}/api/f/${name}/inbox`, {
+    method: 'POST',
+    headers: { 'x-fragment-inbox-token': inboxToken },
+    body: JSON.stringify({ source: 'e2e', payload: { via: 'header' } }),
+  });
+  const hdrBody = await hdrTok.json();
+  eq(hdrBody?.ok, true, 'inbox via x-fragment-inbox-token header accepted');
+
+  // run tokens are header-only (ctx shim's contract): a query-param token,
+  // valid or not, must never reach the internal plane
+  const qtok = await fetch(`${BASE}/__internal/f/${name}/__internal/secrets/all?t=junk`, {
+    headers: { 'x-fragment-host-secret': process.env.FRAGMENT_HOST_SECRET || '' },
+  });
+  ok(qtok.status === 403 && !JSON.stringify(await qtok.json()).includes('files'),
+    'internal plane ignores ?t= query-param tokens');
   const post = await fetch(`${BASE}/api/f/${name}/inbox?t=${inboxToken}`, {
     method: 'POST', body: JSON.stringify({ source: 'e2e', payload: { x: 1 } }),
   });

--- a/scripts/e2e.mjs
+++ b/scripts/e2e.mjs
@@ -22,7 +22,6 @@ const has = (n) => args.includes(n);
 const BASE = arg('--base') || process.env.FRAGMENT_BASE_URL || 'http://127.0.0.1:8789';
 const ONLY = arg('--only');
 const CRON = has('--all');
-const FAST = has('--fast');
 
 // ---------- tiny harness ----------
 let pass = 0, fail = 0;
@@ -452,7 +451,10 @@ function findBinary() {
 
 // ---------- cron (slow) ----------
 async function cronSection() {
-  if (FAST) return;
+  if (!CRON) {
+    if (!ONLY || ONLY === 'cron') console.log('skip  cron fire check is slow — pass --all to include it');
+    return;
+  }
   if (!section('cron')) return;
   const name = `e2e-cr-${suffix}`;
   await signed('POST', '/api/fragments', JSON.stringify({ name }));


### PR DESCRIPTION
## Run tokens: `?t=` is gone

Run/draft/app tokens unlock `ctx.files`, `ctx.secrets`, and `ctx.state` for one isolate. They were accepted via **both** the `x-fragment-token` header and a `?t=` query param — and query params land in access logs, proxy logs, and browser history. A logged run token is a fragment-wide capability leak.

Nothing legitimate ever used the query form (the ctx shim has only ever sent the header), so it's removed outright. The cell now ignores `?t=` on the internal plane entirely — even with the host secret present.

## Inbox: header added, `?t=` kept

The inbox keeps its documented `?t=` — webhook ergonomics for CLI users and external posters — but also accepts an `x-fragment-inbox-token` header, and docs/GUIDE now steer callers who control their clients toward it so the secret stays out of logs.

## Timing-safe compares start here

Adds `safeEqual()` to `auth.js` (XOR-fold over zero-padded UTF-8, length folded into the accumulator) and uses it for the inbox token compare. The view-token comparisons switch to it in the stacked follow-up.

## e2e additions

- internal plane ignores `?t=` tokens even when the host secret gate passes
- inbox works via the `x-fragment-inbox-token` header
- `--all` now actually gates the slow cron-fire check (README said it did; the flag was a no-op)

Verified live against MinIO + celld: full suite green including the new checks.